### PR TITLE
Pass clippy diagnostics to rust-analyzer

### DIFF
--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,5 +1,6 @@
 {
   "editor.formatOnSave": true,
+  "rust-analyzer.diagnostics.experimental.enable": true,
   "[rust]": {
     "editor.defaultFormatter": "rust-lang.rust-analyzer"
   },
@@ -23,6 +24,10 @@
     "stdout",
     "--config-path",
     "__WORKSPACE_ROOT__/rustfmt.toml"
+  ],
+  "rust-analyzer.check.overrideCommand": [
+    "__WORKSPACE_ROOT__/tools/vscode/rust-analyzer-check.bash",
+    "{label}"
   ],
   "rust-analyzer.server.path": "__RUST_ANALYZER_PATH__",
   "rust-analyzer.workspace.discoverConfig": {

--- a/tools/vscode/rust-analyzer-check.bash
+++ b/tools/vscode/rust-analyzer-check.bash
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workspace_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+label_arg="${1:-}"
+
+startup_options=(
+    "--output_base=$workspace_dir/bazel-rust-analyzer"
+)
+
+common_args=(
+    "--@rules_rust//rust/settings:rustc_output_diagnostics=true"
+    "--@rules_rust//rust/settings:clippy_output_diagnostics=true"
+    "--@rules_rust//rust/settings:capture_clippy_output=true"
+    "--@rules_rust//rust/settings:error_format=json"
+    "--output_groups=+clippy_output"
+)
+
+label="$label_arg"
+
+if [ -z "$label" ] || [ "$label" = "{label}" ]; then
+    echo "rust-analyzer-check: missing Bazel label from rust-analyzer" >&2
+    exit 1
+fi
+
+build_output="$(mktemp)"
+cleanup() {
+    rm -f "$build_output"
+}
+trap cleanup EXIT
+
+build_status=0
+if ! bazel "${startup_options[@]}" \
+    build "${common_args[@]}" "$label" >"$build_output" 2>&1; then
+    build_status=$?
+fi
+
+grep '^{.*}$' "$build_output" || true
+
+if [ "$build_status" -eq 0 ]; then
+    execution_root="$(bazel "${startup_options[@]}" info execution_root 2>/dev/null)"
+
+    mapfile -t outputs < <(
+        bazel "${startup_options[@]}" \
+            cquery "${common_args[@]}" --output=files "$label" 2>/dev/null |
+            grep '\.clippy\.diagnostics$' || true
+    )
+
+    for output in "${outputs[@]}"; do
+        if [ -f "$execution_root/$output" ]; then
+            cat "$execution_root/$output"
+        fi
+    done
+fi
+
+if grep -q '^{.*}$' "$build_output"; then
+    exit 0
+fi
+
+exit "$build_status"


### PR DESCRIPTION
Add a Bazel-backed rust-analyzer check command to surface rustc and Clippy diagnostics in VS Code.

This change configures `rust-analyzer.check.overrideCommand` to invoke a small helper script that runs `bazel build` for the current discovered Bazel label with `rules_rust` JSON diagnostic output enabled, then forwards the resulting diagnostic stream back to rust-analyzer. This is necessary because the workspace is modeled through Bazel `discoverConfig` rather than Cargo, so `rust-analyzer.check.command = "clippy"` alone does not provide save-time diagnostics. The change also enables rust-analyzer’s experimental diagnostics to restore semantic diagnostics from the language server itself.
