### PR TITLE
add `emit_asm` rule

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+load("//tools/emit_asm:emit_asm.bzl", "emit_asm")
 
 package(default_visibility = ["//:__subpackages__"])
 
@@ -62,4 +63,10 @@ rust_library(
 rust_test(
     name = "mdspan_test",
     crate = ":mdspan",
+)
+
+emit_asm(
+    name = "mod_layout_asm",
+    testonly = True,
+    src = ":mod_layout_test",
 )

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -71,6 +71,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[inline(never)]
     fn test_layout_left_mapping() {
         let mapping = LayoutLeftMapping([2, 2]);
 
@@ -85,6 +86,7 @@ mod tests {
     }
 
     #[test]
+    #[inline(never)]
     #[should_panic(expected = "dimension out of bounds")]
     fn test_layout_left_mapping_stride_out_of_bounds() {
         let mapping = LayoutLeftMapping([4, 3, 2]);
@@ -92,6 +94,7 @@ mod tests {
     }
 
     #[test]
+    #[inline(never)]
     fn test_layout_right_mapping() {
         let mapping = LayoutRightMapping([2, 2]);
 
@@ -106,6 +109,7 @@ mod tests {
     }
 
     #[test]
+    #[inline(never)]
     #[should_panic(expected = "dimension out of bounds")]
     fn test_layout_right_mapping_stride_out_of_bounds() {
         let mapping = LayoutRightMapping([4, 3, 2]);

--- a/tools/emit_asm/emit_asm.bzl
+++ b/tools/emit_asm/emit_asm.bzl
@@ -1,4 +1,11 @@
-visibility("//tools/emit_asm/...")
+load(
+    "@rules_rust//rust:rust_common.bzl",
+    "CrateInfo",
+    "DepInfo",
+    _RUST_COMMON_PROVIDERS = "COMMON_PROVIDERS",
+)
+
+visibility("///...")
 
 def _sysroot(toolchain):
     """Derive --sysroot from the rustc executable path.
@@ -122,3 +129,53 @@ cat {infile} | {rustfilt} > {outfile}
     )
 
     return asm_file
+
+def _emit_asm_impl(ctx):
+    crate_info = ctx.attr.src[CrateInfo]
+    dep_info = ctx.attr.src[DepInfo]
+    toolchain = ctx.toolchains["@rules_rust//rust:toolchain_type"]
+
+    rustc_flags = list(ctx.attr.rustc_flags)
+    if (ctx.attr.opt):
+        rustc_flags.extend([
+            "-C",
+            "opt-level={}".format(ctx.attr.opt),
+        ])
+
+    asm_file = emit_asm_action(
+        ctx,
+        crate_info,
+        dep_info,
+        toolchain,
+        rustc_flags,
+    )
+
+    return [
+        DefaultInfo(files = depset([asm_file])),
+        OutputGroupInfo(asm = depset([asm_file])),
+    ]
+
+emit_asm = rule(
+    implementation = _emit_asm_impl,
+    attrs = {
+        "src": attr.label(
+            mandatory = True,
+            providers = _RUST_COMMON_PROVIDERS,
+            doc = "rust_library, rust_binary, or rust_test target",
+        ),
+        "rustc_flags": attr.string_list(
+            doc = "additional rustc flags",
+        ),
+        "opt": attr.string(
+            default = "2",
+            values = ["", "0", "1", "2", "3", "s", "z"],
+            doc = "rustc opt-level",
+        ),
+        "_rustfilt": attr.label(
+            default = "@bindeps//:rustfilt__rustfilt",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+    toolchains = ["@rules_rust//rust:toolchain_type"],
+)


### PR DESCRIPTION
Adds a standalone `emit_asm` rule alongside the existing aspect, sharing the same `emit_asm_action` helper. The rule takes a `src` label pointing to any Rust target and an `opt` string attribute controlling the optimization level, making it convenient to declare persistent asm targets in BUILD files without needing to pass aspect flags on the command line.

Adds an `emit_asm` target for `mod_layout_test` in `src/BUILD.bazel` as the first usage, and marks the layout test functions `#[inline(never)]` so they appear as discrete, named functions in the output rather than being inlined away.